### PR TITLE
feature: add contact us section at bottom of about page

### DIFF
--- a/src/components/contact/interactive-business-card.astro
+++ b/src/components/contact/interactive-business-card.astro
@@ -2,8 +2,7 @@
 import BusinessCard from "@components/contact/sponsorship/business-card.astro";
 ---
 
-<div id="contact-us" class="flex flex-col w-full items-center mt-8 gap-y-16">
-  <span class="text-xl font-medium">Contact us</span>
+<div id="contact-us" class="flex flex-col w-full items-center mt-16 gap-y-16">
   <div
     class="relative h-64 w-full items-center flex flex-col scale-85 sm:scale-100">
     <BusinessCard class="absolute rotate-1 translate-y-4" />

--- a/src/components/contact/interactive-business-card.astro
+++ b/src/components/contact/interactive-business-card.astro
@@ -1,0 +1,18 @@
+---
+import BusinessCard from "@components/contact/sponsorship/business-card.astro";
+---
+
+<div id="contact-us" class="flex flex-col w-full items-center mt-8 gap-y-16">
+  <span class="text-xl font-medium">Contact us</span>
+  <div
+    class="relative h-64 w-full items-center flex flex-col scale-85 sm:scale-100">
+    <BusinessCard class="absolute rotate-1 translate-y-4" />
+    <BusinessCard class="absolute rotate-0 translate-y-2" />
+    <BusinessCard class="absolute -rotate-1" />
+    <BusinessCard class="absolute -rotate-2 -translate-y-2" />
+    <div
+      class="absolute -rotate-3 -translate-y-4 lg:motion-safe:hover:-translate-y-12 lg:motion-safe:hover:rotate-0 transition pb-12">
+      <BusinessCard />
+    </div>
+  </div>
+</div>

--- a/src/components/contact/interactive-business-card.astro
+++ b/src/components/contact/interactive-business-card.astro
@@ -2,7 +2,7 @@
 import BusinessCard from "@components/contact/sponsorship/business-card.astro";
 ---
 
-<div id="contact-us" class="flex flex-col w-full items-center mt-16 gap-y-16">
+<div id="contact-us" class="flex flex-col w-full items-center mt-16 gap-y-16 prose-a:!text-black">
   <div
     class="relative h-64 w-full items-center flex flex-col scale-85 sm:scale-100">
     <BusinessCard class="absolute rotate-1 translate-y-4" />

--- a/src/components/contact/interactive-business-card.astro
+++ b/src/components/contact/interactive-business-card.astro
@@ -2,7 +2,9 @@
 import BusinessCard from "@components/contact/sponsorship/business-card.astro";
 ---
 
-<div id="contact-us" class="flex flex-col w-full items-center mt-16 gap-y-16 prose-a:!text-black">
+<div
+  id="contact-us"
+  class="flex flex-col w-full items-center mt-16 gap-y-16 prose-a:!text-black">
   <div
     class="relative h-64 w-full items-center flex flex-col scale-85 sm:scale-100">
     <BusinessCard class="absolute rotate-1 translate-y-4" />

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -44,9 +44,9 @@ import InteractiveBusinessCard from "@components/contact/interactive-business-ca
     </div>
   </section>
   <section>
-  # SES <mark>Contact</mark>
-  <div class="interactive-business-card">
+    # SES <mark>Contact</mark>
+    <div class="prose-a:!text-black">
       <InteractiveBusinessCard />
-  </div>
+    </div>
   </section>
 </MarkdownLayout>

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -45,8 +45,6 @@ import InteractiveBusinessCard from "@components/contact/interactive-business-ca
   </section>
   <section>
     # SES <mark>Contact</mark>
-    <div class="prose-a:!text-black">
       <InteractiveBusinessCard />
-    </div>
   </section>
 </MarkdownLayout>

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,5 +1,6 @@
 import MarkdownLayout from "@layouts/MarkdownLayout.astro";
 import TeamList from "@components/about/team-list.astro";
+import InteractiveBusinessCard from "@components/contact/interactive-business-card.astro";
 
 <MarkdownLayout title="About Us" description="Learn more about who we are!">
   <section>
@@ -41,5 +42,11 @@ import TeamList from "@components/about/team-list.astro";
     <div class="team-container">
       <TeamList />
     </div>
+  </section>
+  <section>
+  # SES <mark>Contact</mark>
+  <div class="interactive-business-card">
+      <InteractiveBusinessCard />
+  </div>
   </section>
 </MarkdownLayout>

--- a/src/pages/contact/sponsorship.astro
+++ b/src/pages/contact/sponsorship.astro
@@ -5,6 +5,7 @@ import PageLayout from "@layouts/PageLayout.astro";
 import { Button } from "@nextui-org/react";
 import { Image } from "astro:assets";
 import { sponsorshipPackageURL } from "data/sponsorship";
+import InteractiveBusinessCard from "@components/contact/interactive-business-card.astro";
 
 const sponsors = await getCollection("pastSponsors");
 ---
@@ -85,19 +86,9 @@ const sponsors = await getCollection("pastSponsors");
 
     <div
       id="contact-us"
-      class="flex flex-col w-full items-center mt-8 gap-y-16">
+      class="flex flex-col w-full items-center mt-8">
       <span class="text-xl font-medium">Contact us</span>
-      <div
-        class="relative h-64 w-full items-center flex flex-col scale-85 sm:scale-100">
-        <BusinessCard class="absolute rotate-1 translate-y-4" />
-        <BusinessCard class="absolute rotate-0 translate-y-2" />
-        <BusinessCard class="absolute -rotate-1" />
-        <BusinessCard class="absolute -rotate-2 -translate-y-2" />
-        <div
-          class="absolute -rotate-3 -translate-y-4 lg:motion-safe:hover:-translate-y-12 lg:motion-safe:hover:rotate-0 transition pb-12">
-          <BusinessCard />
-        </div>
-      </div>
+      <InteractiveBusinessCard />
     </div>
   </div>
 </PageLayout>

--- a/src/pages/contact/sponsorship.astro
+++ b/src/pages/contact/sponsorship.astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from "astro:content";
-import BusinessCard from "@components/contact/sponsorship/business-card.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 import { Button } from "@nextui-org/react";
 import { Image } from "astro:assets";
@@ -84,9 +83,7 @@ const sponsors = await getCollection("pastSponsors");
       )
     }
 
-    <div
-      id="contact-us"
-      class="flex flex-col w-full items-center mt-8">
+    <div id="contact-us" class="flex flex-col w-full items-center mt-8">
       <span class="text-xl font-medium">Contact us</span>
       <InteractiveBusinessCard />
     </div>


### PR DESCRIPTION
## GitHub Issue

<!-- Please mention the GitHub Issue number that this pull request is related to -->

Issue #40 

## Description

<!-- Please provide a brief description of the changes made in this pull request -->
Create a new component for interactive business card and import that to the bottom of the about page

## Screenshots (if applicable)

<!-- If your changes include any visual updates, please attach relevant screenshots here -->
<img width="1498" height="793" alt="image" src="https://github.com/user-attachments/assets/519bed3b-0eb9-4c48-82b0-581468d62a73" />


## Checklist

- [x] The branch has been rebased with the latest `staging` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
