### PR TITLE
chore: update internship lists

### DIFF
--- a/src/content/internshipLists/dannny-babs-canadian-tech-internships-2025.md
+++ b/src/content/internshipLists/dannny-babs-canadian-tech-internships-2025.md
@@ -1,5 +1,0 @@
----
-title: "Canadian-Tech-And-Business-Internships-Summer-2025"
-link: "https://github.com/IsaiahIruoha/Canadian-Tech-And-Business-Internships-Summer-2025"
-author: "IsaiahIruoha"
----

--- a/src/content/internshipLists/dannny-babs-canadian-tech-internships-20255 copy.md
+++ b/src/content/internshipLists/dannny-babs-canadian-tech-internships-20255 copy.md
@@ -1,5 +1,0 @@
----
-title: "Canadian-Tech-Internships-2025"
-link: "https://github.com/Dannny-Babs/Canadian-Tech-Internships-2025"
-author: "Dannny-Babs"
----

--- a/src/content/internshipLists/discord-cscareers.md
+++ b/src/content/internshipLists/discord-cscareers.md
@@ -1,0 +1,5 @@
+---
+title: "CSCareers Discord Server"
+link: "https://discord.gg/cscareers"
+author: "CSCareers Discord"
+--- 

--- a/src/content/internshipLists/discord-cscareers.md
+++ b/src/content/internshipLists/discord-cscareers.md
@@ -2,4 +2,4 @@
 title: "CSCareers Discord Server"
 link: "https://discord.gg/cscareers"
 author: "CSCareers Discord"
---- 
+---

--- a/src/content/internshipLists/gdsc-mcmasteru-canadian-internships.md
+++ b/src/content/internshipLists/gdsc-mcmasteru-canadian-internships.md
@@ -1,5 +1,0 @@
----
-title: "Canadian-Internships"
-link: "https://github.com/DSC-McMaster-U/Canadian-Internships"
-author: "GDSC McMasterU"
----

--- a/src/content/internshipLists/jobright-intern-list.md
+++ b/src/content/internshipLists/jobright-intern-list.md
@@ -2,4 +2,4 @@
 title: "Jobright.ai 2026 Intern List"
 link: "https://www.intern-list.com/"
 author: "Jobright.ai"
---- 
+---

--- a/src/content/internshipLists/jobright-intern-list.md
+++ b/src/content/internshipLists/jobright-intern-list.md
@@ -1,0 +1,5 @@
+---
+title: "Jobright.ai 2026 Intern List"
+link: "https://www.intern-list.com/"
+author: "Jobright.ai"
+--- 

--- a/src/content/internshipLists/simplify-2026-internships.md
+++ b/src/content/internshipLists/simplify-2026-internships.md
@@ -1,0 +1,5 @@
+---
+title: "Simplify Summer 2026 Internships"
+link: "https://github.com/SimplifyJobs/Summer2026-Internships"
+author: "SimplifyJobs"
+--- 

--- a/src/content/internshipLists/simplify-2026-internships.md
+++ b/src/content/internshipLists/simplify-2026-internships.md
@@ -2,4 +2,4 @@
 title: "Simplify Summer 2026 Internships"
 link: "https://github.com/SimplifyJobs/Summer2026-Internships"
 author: "SimplifyJobs"
---- 
+---

--- a/src/content/internshipLists/simplify-copilot.md
+++ b/src/content/internshipLists/simplify-copilot.md
@@ -1,0 +1,5 @@
+---
+title: "Simplify CoPilot Application Autofill"
+link: "https://lnkd.in/gSYmsG-z"
+author: "SimplifyJobs"
+--- 

--- a/src/content/internshipLists/simplify-copilot.md
+++ b/src/content/internshipLists/simplify-copilot.md
@@ -1,5 +1,0 @@
----
-title: "Simplify CoPilot Application Autofill"
-link: "https://lnkd.in/gSYmsG-z"
-author: "SimplifyJobs"
---- 

--- a/src/content/internshipLists/swelist.md
+++ b/src/content/internshipLists/swelist.md
@@ -1,0 +1,5 @@
+---
+title: "Swelist"
+link: "https://swelist.com/"
+author: "Swelist"
+--- 

--- a/src/content/internshipLists/swelist.md
+++ b/src/content/internshipLists/swelist.md
@@ -2,4 +2,4 @@
 title: "Swelist"
 link: "https://swelist.com/"
 author: "Swelist"
---- 
+---


### PR DESCRIPTION
## GitHub Issue

<!-- Please mention the GitHub Issue number that this pull request is related to -->

Issue #154

## Description
Updated the internship list with fall 2025 & 2026 internship links.
<!-- Please provide a brief description of the changes made in this pull request -->

## Screenshots (if applicable)

<!-- If your changes include any visual updates, please attach relevant screenshots here -->
<img width="1918" height="1008" alt="image" src="https://github.com/user-attachments/assets/4525bc54-fb64-4d51-aa2e-118a50fcb06d" />

## Checklist

- [x] The branch has been rebased with the latest `staging` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
