### PR TITLE
fix: #170, change icon for New Grad Postings

### DIFF
--- a/src/pages/experiences.astro
+++ b/src/pages/experiences.astro
@@ -6,6 +6,7 @@ import { FaBriefcase } from "@react-icons/all-files/fa/FaBriefcase";
 import { FaPeopleCarry } from "@react-icons/all-files/fa/FaPeopleCarry";
 import { FaLaptop } from "@react-icons/all-files/fa/FaLaptop";
 import { FaPersonChalkboard } from "@react-icons/all-files/fa6/FaPersonChalkboard";
+import { FaGraduationCap } from "@react-icons/all-files/fa/FaGraduationCap";
 import type { ExperienceLink } from "types/experiences";
 
 const links: ExperienceLink[] = [
@@ -18,7 +19,7 @@ const links: ExperienceLink[] = [
   {
     title: "New Grad Postings",
     description: "Find new grad postings.",
-    icon: FaBriefcase,
+    icon: FaGraduationCap,
     href: "/experiences/newGrad/",
   },
   {


### PR DESCRIPTION
## GitHub Issue

<!-- Please mention the GitHub Issue number that this pull request is related to -->

Issue #170

## Description

<!-- Please provide a brief description of the changes made in this pull request -->

Changed the icon for new-grad-page in experiences page

## Screenshots (if applicable)
Before:
<img width="1700" height="1450" alt="image" src="https://github.com/user-attachments/assets/e2d02dfe-5b21-4f3c-9dc2-ba0faa8f86a2" />

After:
<img width="1668" height="1196" alt="image" src="https://github.com/user-attachments/assets/c1804a83-9e6e-4c09-bbd9-9607c3dbf232" />

<!-- If your changes include any visual updates, please attach relevant screenshots here -->

## Checklist

- [ ] The branch has been rebased with the latest `staging` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
