### PR TITLE
Chore75/updated social media links and icons for team, technical and other clubs.

### DIFF
--- a/src/components/experiences/clubs-and-teams/club-team-item.astro
+++ b/src/components/experiences/clubs-and-teams/club-team-item.astro
@@ -5,6 +5,11 @@ import { IoGlobeOutline } from "@react-icons/all-files/io5/IoGlobeOutline";
 import { IoMailOutline } from "@react-icons/all-files/io5/IoMailOutline";
 import { FaGithub } from "@react-icons/all-files/fa/FaGithub";
 import { FaLinkedinIn } from "@react-icons/all-files/fa/FaLinkedinIn";
+import { FaFacebook } from "@react-icons/all-files/fa/FaFacebook";
+import { FaYoutube } from "@react-icons/all-files/fa/FaYoutube";
+import { FaTiktok } from "@react-icons/all-files/fa6/FaTiktok";
+import { SiLinktree } from "@react-icons/all-files/si/SiLinktree";
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord";
 
 export interface Props {
   name: string;
@@ -20,6 +25,11 @@ export interface Props {
     linkedin?: string;
     website?: string;
     email?: string;
+    facebook?: string;
+    youtube?: string;
+    tiktok?: string;
+    linktree?: string;
+    discord?: string;
   };
 }
 
@@ -93,6 +103,52 @@ const { name, image, description, socials } = Astro.props;
           <a href={`mailto:${socials.email}`} class="rounded-full">
             <div class="text-slate-200 hover:text-primary text-lg">
               <IoMailOutline />
+            </div>
+          </a>
+        )
+      }
+
+      {
+        socials?.facebook && (
+          <a href={socials.facebook} class="rounded-full">
+            <div class="text-slate-200 hover:text-primary text-lg">
+              <FaFacebook />
+            </div>
+          </a>
+        )
+      }
+      {
+        socials?.youtube && (
+          <a href={socials.youtube} class="rounded-full">
+            <div class="text-slate-200 hover:text-primary text-lg">
+              <FaYoutube />
+            </div>
+          </a>
+        )
+      }
+      {
+        socials?.tiktok && (
+          <a href={socials.tiktok} class="rounded-full">
+            <div class="text-slate-200 hover:text-primary text-lg">
+              <FaTiktok />
+            </div>
+          </a>
+        )
+      }
+      {
+        socials?.linktree && (
+          <a href={socials.linktree} class="rounded-full">
+            <div class="text-slate-200 hover:text-primary text-lg">
+              <SiLinktree />
+            </div>
+          </a>
+        )
+      }
+      {
+        socials?.discord && (
+          <a href={socials.discord} class="rounded-full">
+            <div class="text-slate-200 hover:text-primary text-lg">
+              <FaDiscord />
             </div>
           </a>
         )

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -64,12 +64,17 @@ const clubTeamCollection = defineCollection({
     }),
     socials: z
       .object({
-        instagram: z.string().optional(),
-        twitter: z.string().optional(),
-        github: z.string().optional(),
-        linkedin: z.string().optional(),
         website: z.string().optional(),
+        instagram: z.string().optional(),
         email: z.string().optional(),
+        linkedin: z.string().optional(),
+        github: z.string().optional(),
+        tiktok: z.string().optional(),
+        twitter: z.string().optional(),
+        facebook: z.string().optional(),
+        youtube: z.string().optional(),
+        linktree: z.string().optional(),
+        discord: z.string().optional(),
       })
       .optional(),
   }),

--- a/src/content/otherClubs/mac-eng-musical.md
+++ b/src/content/otherClubs/mac-eng-musical.md
@@ -6,5 +6,12 @@ image:
     src: "/experiences/clubs-and-teams/macengmusical-logo.png",
     alt: "Mac Eng Musical logo",
   }
-socials: { website: "https://www.macengmusical.com/" }
+socials:
+  {
+    website: "https://www.macengmusical.com/",
+    instagram: "https://www.instagram.com/macengmusical",
+    facebook: "https://www.facebook.com/macengmusical/",
+    linktree: "https://linktr.ee/macengmusical",
+    youtube: "https://www.youtube.com/user/macengmusical",
+  }
 ---

--- a/src/content/otherClubs/mcmaster-engineering-rugby.md
+++ b/src/content/otherClubs/mcmaster-engineering-rugby.md
@@ -6,5 +6,9 @@ image:
     src: "/experiences/clubs-and-teams/macengrugby-logo.png",
     alt: "McMaster Engineering Rugby logo",
   }
-socials: { instagram: "https://www.instagram.com/macengrugby/" }
+socials:
+  {
+    instagram: "https://www.instagram.com/macengrugby/",
+    linktree: "https://linktr.ee/macengrugby",
+  }
 ---

--- a/src/content/otherClubs/mcmaster-engineers-with-disabilities.md
+++ b/src/content/otherClubs/mcmaster-engineers-with-disabilities.md
@@ -8,5 +8,9 @@ image:
     src: "/experiences/clubs-and-teams/ewd-logo.png",
     alt: "McMaster Engineers With Disabilities logo",
   }
-socials: { instagram: "https://www.instagram.com/mcmasterewd/" }
+socials:
+  {
+    instagram: "https://www.instagram.com/mcmasterewd/",
+    linktree: "https://linktr.ee/mcmasterewd",
+  }
 ---

--- a/src/content/otherClubs/mcmaster-engiqueers.md
+++ b/src/content/otherClubs/mcmaster-engiqueers.md
@@ -10,5 +10,11 @@ image:
     src: "/experiences/clubs-and-teams/engiqueers-logo.png",
     alt: "McMaster EngiQueers logo",
   }
-socials: { website: "https://mcmasterengiqueers.wixsite.com/home/" }
+socials:
+  {
+    website: "https://mcmasterengiqueers.wixsite.com/home/",
+    instagram: "https://www.instagram.com/mcmasterengiqueers",
+    linktree: "https://linktr.ee/macengiqueers",
+    twitter: "https://twitter.com/mcmastereq?s=21&t=HNvs7366Fu23YSDAcoys1Q",
+  }
 ---

--- a/src/content/otherClubs/mcmaster-women-in-engineering.md
+++ b/src/content/otherClubs/mcmaster-women-in-engineering.md
@@ -9,5 +9,10 @@ image:
     src: "/experiences/clubs-and-teams/wie-logo.jpg",
     alt: "McMaster Women in Engineering logo",
   }
-socials: { website: "https://www.mcmasterwie.com/" }
+socials:
+  {
+    website: "https://www.mcmasterwie.com/",
+    instagram: "https://www.instagram.com/mcmasterwie",
+    linktree: "https://linktr.ee/Mcmasterwie",
+  }
 ---

--- a/src/content/otherClubs/national-society-of-black-engineers.md
+++ b/src/content/otherClubs/national-society-of-black-engineers.md
@@ -10,5 +10,10 @@ image:
     src: "/experiences/clubs-and-teams/nsbe-logo.jpg",
     alt: "National Society of Black Engineers logo",
   }
-socials: { website: "https://nsbemcmaster.ca/" }
+socials:
+  {
+    website: "https://nsbemcmaster.ca/",
+    instagram: "https://www.instagram.com/nsbemac",
+    linktree: "https://linktr.ee/NSBEMac",
+  }
 ---

--- a/src/content/technicalClubs/gdsc.md
+++ b/src/content/technicalClubs/gdsc.md
@@ -6,5 +6,14 @@ image:
     src: "/experiences/clubs-and-teams/gdsc-logo.png",
     alt: "GDSC McMasterU logo",
   }
-socials: { website: "https://gdscmcmasteru.ca/" }
+socials:
+  {
+    website: "https://gdscmcmasteru.ca/",
+    instagram: "https://www.instagram.com/gdgmcmaster?igsh=Y2owb2plbnhrMzU0",
+    linkedin: "https://www.linkedin.com/company/gdscmcmasteru",
+    facebook: "https://www.facebook.com/GDSCMcMasterU/",
+    linktree: "https://linktr.ee/gdscmcmasteru",
+    youtube: "https://www.youtube.com/channel/UCyxVVPDEYRCjL0lcwoX9lzA",
+    discord: "https://discord.com/invite/Gme4SfWyzF",
+  }
 ---

--- a/src/content/technicalClubs/mac-ai.md
+++ b/src/content/technicalClubs/mac-ai.md
@@ -2,5 +2,10 @@
 name: "Mac AI Society"
 description: "The McMaster Artificial Intelligence Society (Mac AI) seeks to connect students with a passion for AI to learn and work together in a fun and productive environment."
 image: { src: "/experiences/clubs-and-teams/macai.png", alt: "Mac AI Logo" }
-socials: { instagram: "https://www.instagram.com/macaisociety/?hl=en" }
+socials:
+  {
+    instagram: "https://www.instagram.com/macaisociety/?hl=en",
+    linkedin: "https://www.linkedin.com/company/mcmasterai",
+    linktree: "https://linktr.ee/macaisociety",
+  }
 ---

--- a/src/content/technicalClubs/mcmaster-start-coding.md
+++ b/src/content/technicalClubs/mcmaster-start-coding.md
@@ -10,5 +10,6 @@ socials:
   {
     website: "http://outreach.mcmaster.ca/",
     instagram: "https://www.instagram.com/macstartcoding/",
+    linktree: "https://linktr.ee/MacStartCoding",
   }
 ---

--- a/src/content/technicalClubs/mcmaster-sumobot.md
+++ b/src/content/technicalClubs/mcmaster-sumobot.md
@@ -6,5 +6,11 @@ image:
     src: "/experiences/clubs-and-teams/sumobot-logo.jpeg",
     alt: "McMaster Sumobot logo",
   }
-socials: { website: "https://www.sumobot.ca/" }
+socials:
+  {
+    website: "https://www.sumobot.ca/",
+    instagram: "https://www.instagram.com/mac_sumobot",
+    linktree: "https://linktr.ee/McMasterSumobot",
+    discord: "https://discord.com/invite/YnZvKqGPkw",
+  }
 ---

--- a/src/content/technicalTeams/mac-eco-car.md
+++ b/src/content/technicalTeams/mac-eco-car.md
@@ -7,5 +7,12 @@ socials:
   {
     website: "https://www.macecocar.ca",
     instagram: "https://www.instagram.com/macengecocar",
+    linkedin: "https://www.linkedin.com/company/mcmaster-engineering-ecocar/",
+    tiktok: "https://www.tiktok.com/@macecocar",
+    twitter: "https://twitter.com/macengecocar?lang=en",
+    facebook: "https://www.facebook.com/MacEngEcoCARChallenge/",
+    
+
+
   }
 ---

--- a/src/content/technicalTeams/mac-robomaster.md
+++ b/src/content/technicalTeams/mac-robomaster.md
@@ -6,5 +6,9 @@ image:
     src: "/experiences/clubs-and-teams/robomaster-logo.png",
     alt: "MAC RoboMaster logo",
   }
-socials: { website: "https://macrobomaster.com/" }
+socials:
+  {
+    website: "https://macrobomaster.com/",
+    instagram: "https://www.instagram.com/macrobomaster",
+  }
 ---

--- a/src/content/technicalTeams/mac-solar-car.md
+++ b/src/content/technicalTeams/mac-solar-car.md
@@ -10,5 +10,7 @@ socials:
   {
     website: "https://www.mcmastersolarcar.com/#/",
     instagram: "https://www.instagram.com/macsolarcar",
+    linkedin: "https://www.linkedin.com/company/mcmaster-solar-car-project",
+    linktree: "https://linktr.ee/mcmastersolarcar",
   }
 ---

--- a/src/content/technicalTeams/mcmaster-competitive-programming.md
+++ b/src/content/technicalTeams/mcmaster-competitive-programming.md
@@ -6,5 +6,10 @@ image:
     src: "/experiences/clubs-and-teams/mcp-logo.png",
     alt: "McMaster Competitive Programming logo",
   }
-socials: { website: "https://mcp-team.com/" }
+socials:
+  {
+    website: "https://mcp-team.com/",
+    instagram: "https://www.instagram.com/maccpteam",
+    discord: "https://discord.gg/qNyrXycNnV",
+  }
 ---


### PR DESCRIPTION

## GitHub Issue 

<!-- Please mention the GitHub Issue number that this pull request is related to -->

Issue #75 

## Description
<!-- Please provide a brief description of the changes made in this pull request -->
Updated social media links to all technical, team and other clubs. Also added new social media icons for Youtube, Linktree, Tiktok, Discord and Facebook. 
Altered - Config.ts, club-team-item.astro and relevant club files. 
Tested all links to confirm they re-directed to the right site. 

## Screenshots 
<img width="1657" height="818" alt="image" src="https://github.com/user-attachments/assets/041fb13d-a7e5-4f96-873b-1c49f8642c22" />

Description: New icons now visible. This is only one example, all clubs have been updated with corresponding social media links. 
<!-- If your changes include any visual updates, please attach relevant screenshots here -->

## Checklist

- [x] The branch has been rebased with the latest `production` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
