### PR TITLE
Improvement/hackathon open new tab

### DIFF
--- a/src/components/experiences/hackathon-conference-item.astro
+++ b/src/components/experiences/hackathon-conference-item.astro
@@ -102,7 +102,13 @@ const formatUpcomingDate = (date: Date): string => {
           <div class="text-xs">
             <FaCircleInfo />
           </div>
-          <a href={hackathon.data.link} class="text-sm" target="_blank" rel="noopener"> Details </a>
+          <a
+            href={hackathon.data.link}
+            class="text-sm"
+            target="_blank"
+            rel="noopener">
+            Details
+          </a>
         </div>
         {
           hackathon.data.date && (

--- a/src/components/experiences/hackathon-conference-item.astro
+++ b/src/components/experiences/hackathon-conference-item.astro
@@ -102,7 +102,7 @@ const formatUpcomingDate = (date: Date): string => {
           <div class="text-xs">
             <FaCircleInfo />
           </div>
-          <a href={hackathon.data.link} class="text-sm"> Details </a>
+          <a href={hackathon.data.link} class="text-sm" target="_blank" rel="noopener"> Details </a>
         </div>
         {
           hackathon.data.date && (


### PR DESCRIPTION
## GitHub Issue

Issue #175 

## Description

Details button on hackathon and conference items now open link in new tab instead of same tab.

## Checklist

- [x] The branch has been rebased with the latest `production` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
