### PR TITLE
feat: add expandable modal and external link target for club team cards

### DIFF
--- a/src/components/experiences/clubs-and-teams/club-team-item.astro
+++ b/src/components/experiences/clubs-and-teams/club-team-item.astro
@@ -10,6 +10,7 @@ import { FaYoutube } from "@react-icons/all-files/fa/FaYoutube";
 import { FaTiktok } from "@react-icons/all-files/fa6/FaTiktok";
 import { SiLinktree } from "@react-icons/all-files/si/SiLinktree";
 import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord";
+import ClubTeamModal from "./club-team-modal";
 
 export interface Props {
   name: string;
@@ -47,7 +48,16 @@ const { name, image, description, socials } = Astro.props;
   </div>
   <div class="hackathon-details col-span-4 flex flex-col gap-y-3 py-3 pr-2">
     <div class="flex flex-col gap-y-1">
-      <span class="md:text-xl font-bold line-clamp-1">{name}</span>
+      <div class="flex flex-row items-center justify-between">
+        <span class="md:text-xl font-bold line-clamp-1">{name}</span>
+        <ClubTeamModal
+          client:load
+          name={name}
+          image={image}
+          description={description}
+          socials={socials}
+        />
+      </div>
       <span class="text-sm line-clamp-3">
         {description}
       </span>
@@ -55,7 +65,11 @@ const { name, image, description, socials } = Astro.props;
     <div class="flex flex-row gap-x-2">
       {
         socials?.instagram && (
-          <a href={socials.instagram} class="rounded-full">
+          <a
+            href={socials.instagram}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaInstagram />
             </div>
@@ -64,7 +78,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.twitter && (
-          <a href={socials.twitter} class="rounded-full">
+          <a
+            href={socials.twitter}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaXTwitter />
             </div>
@@ -73,7 +91,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.github && (
-          <a href={socials.github} class="rounded-full">
+          <a
+            href={socials.github}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaGithub />
             </div>
@@ -82,7 +104,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.linkedin && (
-          <a href={socials.linkedin} class="rounded-full">
+          <a
+            href={socials.linkedin}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaLinkedinIn />
             </div>
@@ -91,7 +117,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.website && (
-          <a href={socials.website} class="rounded-full">
+          <a
+            href={socials.website}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <IoGlobeOutline />
             </div>
@@ -110,7 +140,11 @@ const { name, image, description, socials } = Astro.props;
 
       {
         socials?.facebook && (
-          <a href={socials.facebook} class="rounded-full">
+          <a
+            href={socials.facebook}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaFacebook />
             </div>
@@ -119,7 +153,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.youtube && (
-          <a href={socials.youtube} class="rounded-full">
+          <a
+            href={socials.youtube}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaYoutube />
             </div>
@@ -128,7 +166,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.tiktok && (
-          <a href={socials.tiktok} class="rounded-full">
+          <a
+            href={socials.tiktok}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaTiktok />
             </div>
@@ -137,7 +179,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.linktree && (
-          <a href={socials.linktree} class="rounded-full">
+          <a
+            href={socials.linktree}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <SiLinktree />
             </div>
@@ -146,7 +192,11 @@ const { name, image, description, socials } = Astro.props;
       }
       {
         socials?.discord && (
-          <a href={socials.discord} class="rounded-full">
+          <a
+            href={socials.discord}
+            class="rounded-full"
+            target="_blank"
+            rel="noopener">
             <div class="text-slate-200 hover:text-primary text-lg">
               <FaDiscord />
             </div>

--- a/src/components/experiences/clubs-and-teams/club-team-modal.tsx
+++ b/src/components/experiences/clubs-and-teams/club-team-modal.tsx
@@ -179,7 +179,7 @@ export default function ClubTeamModal({
         onClick={onOpen}
         aria-label="Expand details"
         className="text-slate-200 hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 p-0 m-0 leading-none">
-        <FaExpandAlt className="w-5 h-5" />
+        <FaExpandAlt className="w-4 h-4" />
       </button>
 
       <Modal

--- a/src/components/experiences/clubs-and-teams/club-team-modal.tsx
+++ b/src/components/experiences/clubs-and-teams/club-team-modal.tsx
@@ -16,7 +16,6 @@ import {
   ModalContent,
   ModalHeader,
   ModalBody,
-  Button,
   useDisclosure,
 } from "@nextui-org/react";
 
@@ -174,14 +173,14 @@ export default function ClubTeamModal({
 
   return (
     <>
-      <Button
-        isIconOnly
-        variant="ghost"
-        onPress={onOpen}
-        className="text-slate-200 hover:text-primary min-w-0 w-8 h-8"
-        aria-label="Expand details">
-        <FaExpandAlt />
-      </Button>
+      {/* Flat icon-only trigger with no outline/border */}
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label="Expand details"
+        className="text-slate-200 hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 p-0 m-0 leading-none">
+        <FaExpandAlt className="w-5 h-5" />
+      </button>
 
       <Modal
         isOpen={isOpen}
@@ -204,11 +203,12 @@ export default function ClubTeamModal({
               </ModalHeader>
               <ModalBody className="pb-6 bg-slate-950">
                 <div className="flex flex-col gap-6">
-                  <div className="flex flex-row gap-4">
+                  {/* Stack on mobile for more content width; row on sm+ */}
+                  <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
                     <img
                       src={image.src}
                       alt={image.alt}
-                      className="rounded-lg w-32 h-32 object-cover flex-shrink-0"
+                      className="rounded-lg object-cover aspect-square flex-shrink-0 w-16 h-16 sm:w-24 sm:h-24 md:w-28 md:h-28 lg:w-32 lg:h-32"
                     />
                     <div className="flex flex-col gap-3 flex-1">
                       <h3 className="text-lg font-semibold text-white">

--- a/src/components/experiences/clubs-and-teams/club-team-modal.tsx
+++ b/src/components/experiences/clubs-and-teams/club-team-modal.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+import { FaExpandAlt } from "@react-icons/all-files/fa/FaExpandAlt";
+import { FaInstagram } from "@react-icons/all-files/fa/FaInstagram";
+import { FaXTwitter } from "@react-icons/all-files/fa6/FaXTwitter";
+import { IoGlobeOutline } from "@react-icons/all-files/io5/IoGlobeOutline";
+import { IoMailOutline } from "@react-icons/all-files/io5/IoMailOutline";
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub";
+import { FaLinkedinIn } from "@react-icons/all-files/fa/FaLinkedinIn";
+import { FaFacebook } from "@react-icons/all-files/fa/FaFacebook";
+import { FaYoutube } from "@react-icons/all-files/fa/FaYoutube";
+import { FaTiktok } from "@react-icons/all-files/fa6/FaTiktok";
+import { SiLinktree } from "@react-icons/all-files/si/SiLinktree";
+import { FaDiscord } from "@react-icons/all-files/fa/FaDiscord";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  Button,
+  useDisclosure,
+} from "@nextui-org/react";
+
+interface Props {
+  name: string;
+  image: {
+    src: string;
+    alt: string;
+  };
+  description: string;
+  socials?: {
+    instagram?: string;
+    twitter?: string;
+    github?: string;
+    linkedin?: string;
+    website?: string;
+    email?: string;
+    facebook?: string;
+    youtube?: string;
+    tiktok?: string;
+    linktree?: string;
+    discord?: string;
+  };
+}
+
+export default function ClubTeamModal({
+  name,
+  image,
+  description,
+  socials,
+}: Props) {
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+  const renderSocialIcons = () => (
+    <div className="flex flex-row gap-x-2 flex-wrap">
+      {socials?.instagram && (
+        <a
+          href={socials.instagram}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaInstagram />
+          </div>
+        </a>
+      )}
+      {socials?.twitter && (
+        <a
+          href={socials.twitter}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaXTwitter />
+          </div>
+        </a>
+      )}
+      {socials?.github && (
+        <a
+          href={socials.github}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaGithub />
+          </div>
+        </a>
+      )}
+      {socials?.linkedin && (
+        <a
+          href={socials.linkedin}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaLinkedinIn />
+          </div>
+        </a>
+      )}
+      {socials?.website && (
+        <a
+          href={socials.website}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <IoGlobeOutline />
+          </div>
+        </a>
+      )}
+      {socials?.email && (
+        <a href={`mailto:${socials.email}`} className="rounded-full">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <IoMailOutline />
+          </div>
+        </a>
+      )}
+      {socials?.facebook && (
+        <a
+          href={socials.facebook}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaFacebook />
+          </div>
+        </a>
+      )}
+      {socials?.youtube && (
+        <a
+          href={socials.youtube}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaYoutube />
+          </div>
+        </a>
+      )}
+      {socials?.tiktok && (
+        <a
+          href={socials.tiktok}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaTiktok />
+          </div>
+        </a>
+      )}
+      {socials?.linktree && (
+        <a
+          href={socials.linktree}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <SiLinktree />
+          </div>
+        </a>
+      )}
+      {socials?.discord && (
+        <a
+          href={socials.discord}
+          className="rounded-full"
+          target="_blank"
+          rel="noopener">
+          <div className="text-slate-200 hover:text-primary text-lg">
+            <FaDiscord />
+          </div>
+        </a>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      <Button
+        isIconOnly
+        variant="ghost"
+        onPress={onOpen}
+        className="text-slate-200 hover:text-primary min-w-0 w-8 h-8"
+        aria-label="Expand details">
+        <FaExpandAlt />
+      </Button>
+
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        size="2xl"
+        scrollBehavior="inside"
+        placement="center"
+        backdrop="opaque"
+        className="dark"
+        classNames={{
+          base: "max-h-[90vh]",
+          wrapper: "items-center justify-center",
+          backdrop: "bg-black/80",
+        }}>
+        <ModalContent className="bg-slate-950 text-white mx-4 my-4 max-w-full">
+          {() => (
+            <>
+              <ModalHeader className="flex flex-col gap-1 bg-slate-950 text-white">
+                <h2 className="text-2xl font-bold text-white">{name}</h2>
+              </ModalHeader>
+              <ModalBody className="pb-6 bg-slate-950">
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-row gap-4">
+                    <img
+                      src={image.src}
+                      alt={image.alt}
+                      className="rounded-lg w-32 h-32 object-cover flex-shrink-0"
+                    />
+                    <div className="flex flex-col gap-3 flex-1">
+                      <h3 className="text-lg font-semibold text-white">
+                        About
+                      </h3>
+                      <p className="text-sm leading-relaxed text-slate-200">
+                        {description}
+                      </p>
+                    </div>
+                  </div>
+
+                  {Object.values(socials || {}).some(Boolean) && (
+                    <div className="flex flex-col gap-3">
+                      <h3 className="text-lg font-semibold text-white">
+                        Connect With Us
+                      </h3>
+                      {renderSocialIcons()}
+                    </div>
+                  )}
+                </div>
+              </ModalBody>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## GitHub Issue

Issue #193
Issue #201 

## Description

Added an expandable modal feature to club/team cards with the following implementation, and an update to links on the card:

- **Expand Button**: Used `FaExpandAlt` from `@react-icons/all-files/fa/FaExpandAlt` as a compact button in the card header
- **Modal Component**: Implemented using NextUI's `Modal`, `ModalContent`, `ModalHeader`, and `ModalBody` components
- **Responsive Layout**: Modal displays club image, full description, and organized social links in a clean layout
- **External Links**: All social links now open in new tabs with `target="_blank"` and `rel="noopener"` for security (modal or not)

The modal provides a better view of club details while maintaining the existing card's compact design and consistent dark theme styling.

## Screenshots (if applicable)

### Desktop
<img width="1917" height="868" alt="image" src="https://github.com/user-attachments/assets/6f590ccb-1b11-484b-8f63-8ff8b48a1ab2" />

### Mobile

![IMG_9445](https://github.com/user-attachments/assets/1d1cee87-42f1-4a04-8752-17d75e235fbc)

## Checklist

- [x] The branch has been rebased with the latest `production` branch
- [x] The code has been tested locally by running `pnpm dev` and verifying that the changes work as expected
- [x] The code has been linted and formatted using `pnpm lint:fix`
- [x] This PR has the project manager assigned as a reviewer
- [x] This PR has myself assigned as the assignee
